### PR TITLE
Add custom repository for bsdtar

### DIFF
--- a/salt/bsdtar/init.sls
+++ b/salt/bsdtar/init.sls
@@ -1,4 +1,20 @@
 # vi: set ft=yaml.jinja :
 
+{% if salt['config.get']('os_family') == 'RedHat' %}
+
+bsdtar-repo:
+  pkgrepo.managed:
+    - humanname: pixz for CentOS and RHEL (CentOS_CentOS-6)
+    - baseurl: http://download.opensuse.org/repositories/home:/AndreasStieger:/branches:/Archiving/CentOS_CentOS-6/
+    - gpgcheck: 1
+    - gpgkey: http://download.opensuse.org/repositories/home:/AndreasStieger:/branches:/Archiving/CentOS_CentOS-6/repodata/repomd.xml.key
+
+{% endif %}
+
 bsdtar:
-  pkg.installed:   []
+  pkg:
+    - installed
+{% if salt['config.get']('os_family') == 'RedHat' %}
+    - require:
+      - pkgrepo: bsdtar-repo
+{% endif %}


### PR DESCRIPTION
fixes #5
bsdtar is not available in the official centOS repositories, therefore add this custom one I found.