### PR TITLE
adding service and role states

### DIFF
--- a/salt/_states/cloudera_role.py
+++ b/salt/_states/cloudera_role.py
@@ -36,3 +36,43 @@ def __virtual__():
     return 'cloudera_role' if HAS_CMAPI else False
 
 
+def present(name, role_type, hostname, service_name,  cluster, **cm_args):
+    '''
+    Ensures that the named role has been added to the cluster.
+
+    role_name
+        The name of the role to add
+        
+    role_type
+        The type of the role to add
+    
+    service_name
+        The name of the service to which the role belongs
+        
+    hostname
+        the name of the host to which the role is going to be assigned
+
+    cluster
+        The name of the cluster on which to add the role
+    '''
+    ret = {'changes' : {},
+           'comment' : '',
+           'name'    : name,
+           'result'  : False}
+    if __salt__['cloudera.role_exists'](name, hostname, service_name, cluster, **cm_args):
+        ret['result'] = True
+        ret['comment'] = 'Role {0} already present'.format(name)
+        return ret
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'Role {0} is set to be added'.format(name)
+        return ret
+    if __salt__['cloudera.role_create'](name, role_type, hostname, service_name, cluster, **cm_args):
+        ret['changes'] = {'old': '', 'new': '{0}'.format(name)}
+        ret['comment'] = 'Added role {0}'.format(name)
+        ret['result'] = True
+        return ret
+    else:
+        ret['comment'] = 'Failed to add role {0}'.format(name)
+        ret['result'] = False
+        return ret

--- a/salt/_states/cloudera_role_group.py
+++ b/salt/_states/cloudera_role_group.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+'''
+Manage Cloudera Services
+========================
+
+:maintainer: Khris Richardson <khris.richardson@gmail.com>
+:maturity:   new
+:depends:    cm_api Python module
+:platform:   all
+
+Example:
+
+.. code-block:: yaml
+
+    HDFS1-NAMENODE-BASE:
+        cloudera_role_group.configure:
+          - cluster: Cluster 1 - CDH5
+          - config:
+            - dfs_replication: 1
+'''
+
+import logging
+
+log = logging.getLogger(__name__)
+
+try:
+    from cm_api.api_client import ApiResource
+    HAS_CMAPI = True
+except ImportError:
+    HAS_CMAPI = False
+
+
+def __virtual__():
+    '''
+    Only load if Cloudera Manager API is available.
+    '''
+    return 'cloudera_role_group' if HAS_CMAPI else False
+
+def configure(name, config, cluster, **cm_args):
+    '''
+    Ensures that the role group is properly configured
+    
+    '''
+    ret = {'changes' : {},
+           'comment' : '',
+           'name'    : name,
+           'result'  : False}
+    old_conf = __salt__['cloudera.role_config_group_get_configuration'](name, cluster, **cm_args)
+    if old_conf is not None and all(item in old_conf.items() for item in config.items()):
+        ret['result'] = True
+        ret['comment'] = 'Role configuration group {0} already configured'.format(name)
+        return ret
+    if __salt__['cloudera.role_config_group_configure'](name, config, cluster, **cm_args):
+        ret['result'] = True
+        ret['comment'] = 'Role configuration group {0} configured.'
+        ret['changes'] = dict( (item, {'old': old_conf.get(item,''), 'new': config[item] }) for item in config.keys() if config[item] != old_conf.get(item,None) )
+        return ret
+    else:
+        ret['result'] = False
+        ret['comment'] = 'Failed to configure role configuration group {0}'.format(name)
+        return ret

--- a/salt/_states/cloudera_service.py
+++ b/salt/_states/cloudera_service.py
@@ -14,6 +14,7 @@ Example:
 
     zookeeper1:
         cloudera_service.present:
+          - service_type: ZOOKEEPER
           - cluster: Cluster 1 - CDH4
 '''
 
@@ -36,7 +37,7 @@ def __virtual__():
     return 'cloudera_service' if HAS_CMAPI else False
 
 
-def present(name, cluster, **cm_args):
+def present(name, service_type, cluster, config=None, **cm_args):
     '''
     Ensures that the named service has been added to the cluster.
 
@@ -50,15 +51,15 @@ def present(name, cluster, **cm_args):
            'comment' : '',
            'name'    : name,
            'result'  : False}
-    if __salt__['cloudera.service_exists'](name, cluster, **cm_args):
+    if __salt__['cloudera.service_exists'](name, service_type, cluster, **cm_args):
         ret['result'] = True
-        ret['comment'] = 'Host {0} already present'.format(name)
+        ret['comment'] = 'Service {0} already present'.format(name)
         return ret
     if __opts__['test']:
         ret['result'] = None
-        ret['comment'] = 'Host {0} is set to be added'.format(name)
+        ret['comment'] = 'Service {0} is set to be added'.format(name)
         return ret
-    if __salt__['cloudera.service_create'](name, cluster, **cm_args):
+    if __salt__['cloudera.service_create'](name, service_type, cluster, config, **cm_args):
         ret['changes'] = {'old': '', 'new': '{0}'.format(name)}
         ret['comment'] = 'Added service {0}'.format(name)
         ret['result'] = True
@@ -85,11 +86,11 @@ def absent(name, cluster, **cm_args):
            'result'  : False}
     if not __salt__['cloudera.service_exists'](name, cluster, **cm_args):
         ret['result'] = True
-        ret['comment'] = 'Host {0} already absent'.format(name)
+        ret['comment'] = 'Service {0} already absent'.format(name)
         return ret
     if __opts__['test']:
         ret['result'] = None
-        ret['comment'] = 'Host {0} is set to be removed'.format(name)
+        ret['comment'] = 'Service {0} is set to be removed'.format(name)
         return ret
     if __salt__['cloudera.service_remove'](name, cluster, **cm_args):
         ret['changes'] = {'old': '{0}'.format(name), 'new': ''}


### PR DESCRIPTION
Role and service stuff

the management service things aren't working, but I found example code from cloudera which could help: https://github.com/cloudera/cm_api/tree/master/python/examples/auto-deploy

Role group configuration works, and I changed the service methods you had to explicitely take the service type instead of inferring from the name. Also the same method can be used for configuration of a service. There is also a state for configuring role groups.

What is not working atm is detecting that the service configuration has changed.

I can look into merge issues after review or something.